### PR TITLE
fix: add fetch timeouts and error handling to accounts-zoho to prevent server freeze

### DIFF
--- a/packages/accounts-zoho/package.js
+++ b/packages/accounts-zoho/package.js
@@ -1,7 +1,7 @@
 Package.describe({
 	name: 'settlin:accounts-zoho',
   summary: "Login service for Zoho accounts",
-  version: "1.0.5",
+  version: "1.0.6",
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
## Summary

- Add **15-second fetch timeouts** to all Zoho API calls using `AbortController`, preventing a hanging Zoho API from blocking a Meteor Fiber indefinitely
- Fix the **double-error pattern** (`callback(error)` + `throw`) that breaks `Meteor.wrapAsync` — now uses `callback` exclusively
- Wrap entire `getAccessToken` in **try/catch** for robust error handling of network failures, DNS issues, and unexpected errors
- Use **`accounts-server` domain from the OAuth callback** for the mail API URL instead of hardcoded `mail.zoho.com`
- Make the **mail accounts API call non-fatal** — OAuth login succeeds even if the mail API call fails (it was only used for `accountId` which was already commented out)

## Context

Production portal at `portal.settlin.in` froze completely **3 times on Feb 18, 2026** (at 06:11, 08:xx, 09:xx UTC), requiring manual server reboots. 

Analysis of nginx proxy logs showed the **first 504 in each freeze was a `/_oauth/zoho` callback**. The old code had:
1. **No timeout** on `fetch()` calls — if Zoho API hung, the Meteor Fiber blocked forever
2. `Meteor.wrapAsync` wrapping an `async` function that both called `callback(error)` AND threw — confusing the Fiber
3. No try/catch — any network error would propagate as an unhandled exception

With enough blocked Fibers (or even just one that never completes), the Meteor server's event loop / Fiber pool gets exhausted, causing total unresponsiveness.

## Version

Bumped to `1.0.6`